### PR TITLE
Paragraph css example

### DIFF
--- a/content/posts/2025-04-06-Doughnut-Dash-2/index.mdx
+++ b/content/posts/2025-04-06-Doughnut-Dash-2/index.mdx
@@ -4,9 +4,13 @@ date: 2025-04-06
 tags:
     - rides
 ---
-
 import Ride from "../../../src/components/ride";
 
+Why are these different size??
+
+Foo
+
+<p> Foo </p>
 
 <Ride 
     instagramUrl="https://www.instagram.com/p/DHmtIAZsIHo/" 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/356238f5-41fa-496e-a8cc-b12b9dbefdf5)

It seems like the paragraph rendered directly from markdown has an extra css class vs in the `<p>`  there is no extra class